### PR TITLE
Fixing template to stop alacritty error

### DIFF
--- a/templates/alacritty.toml.j2
+++ b/templates/alacritty.toml.j2
@@ -26,7 +26,7 @@ foreground = '{{term.color15}}'
 [font]
 size = {{font.mono.size}}
 
-[font.normal.family]
+[font.normal]
 family = "{{font.mono.family}}"
 
 [[keyboard.bindings]]


### PR DESCRIPTION
Alacritty throws an error about invalid family map type. After tweaking my own config. Found out it's the fact that [font.normal.family] should just be [font.normal]